### PR TITLE
Fix empty _index.md on hugo new

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,16 @@ The `exampleSiteNoAlbum` directory demonstrates a no-album layout, where all pho
 
 Inside your project create the directory `assets/NAME-OF-YOUR-ALBUM`.  Place all of one album's photos inside that directory.
 
-Make sure that the theme [archetype file](https://gohugo.io/content-management/archetypes/) is used. It is responsible for the `hugo new` hook. 
-```
-$ cp themes/autophugo/archetypes/default.md archetypes/default.md
-```
-
-Inside your project run:
+***Please Note!*** If you have not previously, make sure hugo uses the theme's [archetype file](https://gohugo.io/content-management/archetypes/) by deleting the default site one. The archetype file is responsible for the `hugo new` hook.
 
 ```
-$ hugo new NAME-OF-YOUR-ALBUM/_index.md
+rm archetypes/default.md
+```
+
+Now, inside your project run:
+
+```
+hugo new NAME-OF-YOUR-ALBUM/_index.md
 ```
 
 It will create an index file for your first album.  Open `content/NAME-OF-YOUR-ALBUM/_index.md` with your text editor. You'll see something like this:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ The `exampleSiteNoAlbum` directory demonstrates a no-album layout, where all pho
 
 Inside your project create the directory `assets/NAME-OF-YOUR-ALBUM`.  Place all of one album's photos inside that directory.
 
+Make sure that the theme [archetype file](https://gohugo.io/content-management/archetypes/) is used. It is responsible for the `hugo new` hook. 
+```
+$ cp themes/autophugo/archetypes/default.md archetypes/default.md
+```
+
 Inside your project run:
 
 ```

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -328,3 +328,4 @@ body, #footer, #header { max-width: 1200px; margin: 0 auto; left: auto; }
 .taxonomy_list h2 { margin-right: 5px; }
 .caption_tax { display: none; }
 .caption-surround .caption_tax { display: flex; flex-wrap: wrap; padding: 0; }
+.invis_desc { display: none; }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -276,19 +276,19 @@ body.ie #main:before { background: rgba(36, 38, 41, 0.55); }
 body.content-active #main { -moz-filter: blur(6px); -webkit-filter: blur(6px); -ms-filter: blur(6px); filter: blur(6px); }
 body.content-active #main:after { -moz-pointer-events: auto; -webkit-pointer-events: auto; -ms-pointer-events: auto; pointer-events: auto; opacity: 1; visibility: visible; }
 body.loading #main .thumb { -moz-pointer-events: none; -webkit-pointer-events: none; -ms-pointer-events: none; pointer-events: none; opacity: 0; visibility: hidden;}
-#main .thumb { -moz-transition-delay: 2.525s; -webkit-transition-delay: 2.525s; -ms-transition-delay: 2.525s; transition-delay: 2.525s; width: 100%; padding: 0px 0px 4px 0px; }
-#main .thumb:nth-child(1) { -moz-transition-delay: 0.65s; -webkit-transition-delay: 0.65s; -ms-transition-delay: 0.65s; transition-delay: 0.65s; }
-#main .thumb:nth-child(2) { -moz-transition-delay: 0.8s; -webkit-transition-delay: 0.8s; -ms-transition-delay: 0.8s; transition-delay: 0.8s; }
-#main .thumb:nth-child(3) { -moz-transition-delay: 0.95s; -webkit-transition-delay: 0.95s; -ms-transition-delay: 0.95s; transition-delay: 0.95s; }
-#main .thumb:nth-child(4) { -moz-transition-delay: 1.1s; -webkit-transition-delay: 1.1s; -ms-transition-delay: 1.1s; transition-delay: 1.1s; }
-#main .thumb:nth-child(5) { -moz-transition-delay: 1.25s; -webkit-transition-delay: 1.25s; -ms-transition-delay: 1.25s; transition-delay: 1.25s; }
-#main .thumb:nth-child(6) { -moz-transition-delay: 1.4s; -webkit-transition-delay: 1.4s; -ms-transition-delay: 1.4s; transition-delay: 1.4s; }
-#main .thumb:nth-child(7) { -moz-transition-delay: 1.55s; -webkit-transition-delay: 1.55s; -ms-transition-delay: 1.55s; transition-delay: 1.55s; }
-#main .thumb:nth-child(8) { -moz-transition-delay: 1.7s; -webkit-transition-delay: 1.7s; -ms-transition-delay: 1.7s; transition-delay: 1.7s; }
-#main .thumb:nth-child(9) { -moz-transition-delay: 1.85s; -webkit-transition-delay: 1.85s; -ms-transition-delay: 1.85s; transition-delay: 1.85s; }
-#main .thumb:nth-child(10) { -moz-transition-delay: 2s; -webkit-transition-delay: 2s; -ms-transition-delay: 2s; transition-delay: 2s; }
-#main .thumb:nth-child(11) { -moz-transition-delay: 2.15s; -webkit-transition-delay: 2.15s; -ms-transition-delay: 2.15s; transition-delay: 2.15s; }
-#main .thumb:nth-child(12) { -moz-transition-delay: 2.3s; -webkit-transition-delay: 2.3s; -ms-transition-delay: 2.3s; transition-delay: 2.3s; }
+#main .thumb { transition-delay: 1.5s; width: 100%; padding: 0px 0px 4px 0px; }
+#main .thumb:nth-child(1) { transition-delay: 0.3s; }
+#main .thumb:nth-child(2) { transition-delay: 0.4s; }
+#main .thumb:nth-child(3) { transition-delay: 0.5s; }
+#main .thumb:nth-child(4) { transition-delay: 0.6s; }
+#main .thumb:nth-child(5) { transition-delay: 0.7s; }
+#main .thumb:nth-child(6) { transition-delay: 0.8s; }
+#main .thumb:nth-child(7) { transition-delay: 0.9s; }
+#main .thumb:nth-child(8) { transition-delay: 1.0s; }
+#main .thumb:nth-child(9) { transition-delay: 1.1s; }
+#main .thumb:nth-child(10) { transition-delay: 1.2s; }
+#main .thumb:nth-child(11) { transition-delay: 1.3s; }
+#main .thumb:nth-child(12) { transition-delay: 1.4s; }
 
 /* Footer */
 #footer .copyright { color: #505051; font-size: 0.9em; }

--- a/layouts/partials/render_img_column_flexrow.html
+++ b/layouts/partials/render_img_column_flexrow.html
@@ -73,13 +73,16 @@
                             id="{{ md5 $filename }}"
                             downloadable="{{ cond $downloadable "true" "false" }}"
                             {{- if $downloadable }}
-                                download_file="{{ (cond $orig_download .orig .full).RelPermalink }}"
+                            download_file="{{ (cond $orig_download .orig .full).RelPermalink }}"
                             {{- end }}
                             orig_name="{{ $filename }}"
                             href="{{ .full.RelPermalink }}">
                         <div id="image_number_{{ .index }}" class="gallery-item-marker"></div>
                         <img src="{{ .thumb.RelPermalink }}"
-                            {{ with .alt }} alt="{{ . }}"{{ end }}>
+                            {{- with .alt }} alt="{{ . }}"{{ end }}>
+                        {{- with .description }}
+                        <div class="invis_desc">{{ (. | markdownify) | safeHTMLAttr }}</div>
+                        {{- end }}
                     </a>
                     {{- if (default false ($.Param "taxonomies_links")) }}
                         <div class="caption_tax">


### PR DESCRIPTION
`hugo new some-dir/_index.md` was creating empty _index.md files. It was caused by an empty `archetypes/default.md` file being automatically added into new projects by hugo new site. Updated documentation to fix album construction.

fixed#38`hugo new some-dir/_index.md` was creating empty _index.md files. It was caused by an empty `archetypes/default.md` file being automatically added into new projects by hugo new site. Updated documentation to fix album construction.

fixed#38